### PR TITLE
feat: cache support + $USE_LATEST_CHROME

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Circleci Use Chrome Stable Version
 
-To force the use of the latest stable version of Chrome on Circle CI, define those lines in your circle.yml configuration file
+To force the use of the latest stable version of Chrome on Circle CI, define those lines in your circle.yml configuration file and set enviromental variable $USE_LATEST_CHROME=true
 
 ```
 dependencies:
-  pre:
-    - curl -s https://raw.githubusercontent.com/chronogolf/circleci-google-chrome/master/use_chrome_stable_version.sh | bash
-```
-
+  cache_directories:
+  - '~/downloads'
+pre:
+  # download the latest Google Chrome if enabled by enviromental variable $USE_LATEST_CHROME
+  - if [[ $USE_LATEST_CHROME == true ]]; then if test -f "$HOME/downloads/use_chrome_stable_version.sh"; then sh $HOME/downloads/use_chrome_stable_version.sh; else curl -o $HOME/downloads/use_chrome_stable_version.sh --create-dirs https://raw.githubusercontent.com/azachar/circleci-google-chrome/master/use_chrome_stable_version.sh && bash $HOME/downloads/use_chrome_stable_version.sh; fi; fi;

--- a/use_chrome_stable_version.sh
+++ b/use_chrome_stable_version.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
-function use_chrome_stable_version {
-  curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb;
+use_chrome_stable_version() {
+  echo 'Upgrading the current Chrome version:';
+  google-chrome --version
+  cd $HOME/downloads
+  if ! test -f "google-chrome.deb"
+  then
+    curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb;
+  fi
   sudo dpkg -i google-chrome.deb;
   sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome;
-  rm google-chrome.deb
+  echo 'The latest Chrome version is:';
+  google-chrome --version
 }
 
 use_chrome_stable_version


### PR DESCRIPTION
Hi there, 
i have implemented a cache feature:

it saves chrome to ~/downloads folder that is cached
downloading is managed by the environmental variable $USE_LATEST_CHROME (if true, it will install the latest chrome, if anything else, it does nothing)

Let me know what do you think.

Cheers,
Andrej